### PR TITLE
luci2-app-dsl: fix angular js warning

### DIFF
--- a/luci2-app-dsl/www/view/status/dsl.html
+++ b/luci2-app-dsl/www/view/status/dsl.html
@@ -31,10 +31,10 @@
 	<legend translate>DSL Line Information header</legend>
 	<div class="l2-grid l2-grid-hover">
 		<div class="row">
-			<div class="cell clearfix content col-xs-4" translate>
-			</div><div class="cell clearfix content nowrap col-xs-4">
+			<div class="cell clearfix content col-xs-4">
+			</div><div class="cell clearfix content nowrap col-xs-4" translate>
 				DSL Downstream
-			</div><div class="cell clearfix content nowrap col-xs-4">
+			</div><div class="cell clearfix content nowrap col-xs-4" translate>
 				DSL Upstream
 			</div>
 		</div>
@@ -107,10 +107,10 @@
 	<legend translate>DSL Performance header</legend>
 	<div class="l2-grid l2-grid-hover">
 		<div class="row">
-			<div class="cell clearfix content col-xs-4" translate>
-			</div><div class="cell clearfix content nowrap col-xs-4">
+			<div class="cell clearfix content col-xs-4">
+			</div><div class="cell clearfix content nowrap col-xs-4" translate>
 				DSL Near End
-			</div><div class="cell clearfix content nowrap col-xs-4">
+			</div><div class="cell clearfix content nowrap col-xs-4" translate>
 				DSL Far End
 			</div>
 		</div>
@@ -253,3 +253,4 @@
 			</div>
 		</div>
 </fieldset>
+


### PR DESCRIPTION
Loading dsl.html generates javascript console warnings,
because no translation text was added

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>