### PR TITLE
luci2-io-helper: fflush send buffer after fwrite on backup read

### DIFF
--- a/luci2-io-helper/src/main.c
+++ b/luci2-io-helper/src/main.c
@@ -621,8 +621,10 @@ main_backup(int argc, char **argv)
 		printf("Content-Disposition: attachment; "
 		       "filename=\"backup-%s-%s.tar.gz\"\r\n\r\n", hostname, datestr);
 
-		while ((len = read(fds[0], buf, sizeof(buf))) > 0)
+		while ((len = read(fds[0], buf, sizeof(buf))) > 0){
 			fwrite(buf, len, 1, stdout);
+			fflush(stdout);
+		}
 
 		waitpid(pid, NULL, 0);
 


### PR DESCRIPTION
In some situations the tar.gz was corrupted because of missing data.
Adding a fflush after the fwrite function solves this issue.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>