### PR TITLE
luci2-io-helper: bugfix buckup script read timeout

### DIFF
--- a/luci2-io-helper/src/main.c
+++ b/luci2-io-helper/src/main.c
@@ -577,6 +577,7 @@ main_backup(int argc, char **argv)
 	pid_t pid;
 	time_t now;
 	int len;
+	int status;
 	int fds[2];
 	char buf[4096];
 	char datestr[16] = { 0 };
@@ -610,6 +611,7 @@ main_backup(int argc, char **argv)
 		return -1;
 
 	default:
+		fcntl(fds[0], F_SETFL, fcntl(fds[0], F_GETFL) | O_NONBLOCK);
 		now = time(NULL);
 		strftime(datestr, sizeof(datestr) - 1, "%Y-%m-%d", localtime(&now));
 
@@ -621,12 +623,15 @@ main_backup(int argc, char **argv)
 		printf("Content-Disposition: attachment; "
 		       "filename=\"backup-%s-%s.tar.gz\"\r\n\r\n", hostname, datestr);
 
-		while ((len = read(fds[0], buf, sizeof(buf))) > 0){
-			fwrite(buf, len, 1, stdout);
-			fflush(stdout);
-		}
+		do{
+			waitpid(pid, &status, 0);
 
-		waitpid(pid, NULL, 0);
+			while ((len = read(fds[0], buf, sizeof(buf))) > 0 ){
+				fwrite(buf, len, 1, stdout);
+				fflush(stdout);
+			}
+
+		}while (!WIFEXITED(status));
 
 		close(fds[0]);
 		close(fds[1]);


### PR DESCRIPTION
Reading files from stdin will block for ever. The uhttpd is killing the
backup process after script_timeout.

Switching read to non blocking mode and add a waitpid for the slave
process does not end in a script_timeout anymore.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>