### PR TITLE
luci2-ui-base: fix acl setup for status view

### DIFF
--- a/luci2-ui-base/share/rpcd/acl.d/luci-ng.json
+++ b/luci2-ui-base/share/rpcd/acl.d/luci-ng.json
@@ -43,7 +43,8 @@
 					"board"
 				],
 				"network.interface": [
-					"status"
+					"status",
+					"dump"
 				],
 				"luci2.network": [
 					"conntrack_count",
@@ -58,6 +59,13 @@
 					"syslog",
 					"dmesg",
 					"process_list"
+				],
+				"network": [
+					"get_proto_handlers"
+				]
+			},
+			"uci" : [
+					"network"
 				]
 			}
 		},


### PR DESCRIPTION
If another user than root is logged in than he is unable to get the
Network status. Updating the acl will solve this issue.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>