### PR TITLE
RFC: add automatic LUCI pages from UCI config files

### DIFF
--- a/luci2-ui-base/docs/autoUCI.json
+++ b/luci2-ui-base/docs/autoUCI.json
@@ -1,0 +1,98 @@
+{
+	//Optional Header section
+	"title": "",				// Title of the config file. Defalut: config file name
+	"description": "",			// General description of the config file. Default: ""
+	"info": "",					// Additional info on the config. Default: ""
+	
+	//Optional configuration for luci2 auto uci pages
+	luci2: {
+		format: "tabs" || "list" || 'hybrid',
+		hideUndeclared: true || false, //autogenerate sections for those present in UCI config file not described in this template. Default: fase
+	},
+	
+	//Required section describing the config file
+	"sections": {
+
+		//Optional configuration for luci2 auto uci pages
+		"luci2": {},
+
+		
+		//one property for each type of section allowed in the config
+		"section_type1": {
+
+			//Optional Header section
+			"title": "",				// Title of the section. Defalut: section_type, if annonymus 'section_type #'
+			"description": "",			// General description of the section. Default: ""
+			"info": "",					// Additional info on the section. Default: ""
+
+			//Optional configuration for luci2 auto uci pages
+			"luci2": {
+				"format": "tabs" || "list" || 'hybrid',
+				"undeclared": true || false, //autogenerate group for options in UCI not described in this template
+				"addremove": true || false,
+				"anonymous": true || false,
+				"sortable": true || false,
+				},
+
+		
+		
+			//Required sections for describing valid options
+			//may be in the form of ungrouped 'options' or inside logical 'groups' of conceptually related options
+			//one (or the two) must be present
+			"options": {
+				
+				//one property for each option
+				"option1_name": {
+					
+					//Optional Header section
+					"title": "",				// Title of the option. Defalut: option_name
+					"description": "",			// General description of the option. Default: ""
+					"info": "",					// Additional info on the option. Default: ""
+					"parameter": "",			// (Optional) Info on the correspondig parameter in the underlying application
+	
+					//Required data description section
+					"type": "<type>" || ["<list type>"],// Expected type of the value. If it is a list type, it must be declared as 
+														// an array, with the first element defining the type. Default: "string"
+														// possible values: any of l2validation types plus 'flag'
+														// default: string
+					"required": true || false,			// value must be present
+					"validation": "expr",				// any additional validation to perform (besides type). It can be any l2validation function
+					"default": "",						// Default value
+					"values": [], 						// array of possible values to select
+														// if type is flag, first value is used for 'on' and second for 'off' rest is discarded. Bool defaults to 1/0
+					
+					"depends": {
+						"optionA_name": [values],		// Option name and possible values, for this option to be enabled
+						"optionB_name": [values],		// if more than one option is defined all must be met
+					}
+
+				},
+				"option2_name": {},
+			},
+
+			// list of options grouped toghether for easier understunging
+			"groups": {
+				
+				//one property for each group of options
+				"group1_name": {
+
+					//Optional Header section
+					"title": "",				// Title of the Group of options. Defalut: group_name
+					"description": "",			// General description of the group. Default: ""
+					"info": "",					// Additional info on the group. Default: ""
+					"parameter": "",			// (Optional) correspondig parameter in the underlying application
+
+					"depends": {				// If dependencies are set for the group, they are inherited by al options of the group
+						"optionA_name": [values],		// Option name and possible values, for this option to be enabled
+						"optionB_name": [values],		// if more than one option is defined all must be met
+					}
+
+					
+					options: {}, 				// same structure as for ungruped options
+					}
+				}
+			}
+		}
+	}
+}
+

--- a/luci2-ui-base/share/rpcd/menu.d/test.json
+++ b/luci2-ui-base/share/rpcd/menu.d/test.json
@@ -1,0 +1,12 @@
+{
+    "test": {
+        "title": "Auto UCI",
+        "index": 30
+    },
+    "test/system": {
+        "title": "System",
+        "acls": [ "system" ],
+        "view": "shared/uci_general",
+        "index": 10
+    },
+}

--- a/luci2-ui-base/www/luci-ng/controller/shared/uci_general.js
+++ b/luci2-ui-base/www/luci-ng/controller/shared/uci_general.js
@@ -1,0 +1,156 @@
+L2.registerController('SharedUci_generalController', ['$scope', '$http', 'l2uci', function ($scope, $http, l2uci) {
+
+	console.log("View controller");
+
+	var configFile = "system";
+
+
+	var self = angular.extend(this, {
+		types: {
+			bool: {
+				elem: "cbiFlag",
+				attr: "on='1' off='0'",
+				validation: false
+			},
+			intenger: true,
+			uinteger: true,
+			float: true,
+			ufloat: true,
+			string: true,
+			ipaddr: true,
+			ip4addr: true,
+			ip6addr: true,
+			netmask4: true,
+			netmask6: true,
+			cidr4: true,
+			cidr6: true,
+			ipmask4: true,
+			ipmask6: true,
+			port: true,
+			portrange: true,
+			macaddr: true,
+			host: true,
+			hostname: true,
+			wpakey: true,
+			wepkey: true,
+			device: {
+				elem: "cbiDeviceList"
+			},
+			network: {
+				elem: "cbiNetworkList"
+			},
+		},
+
+		config: null,
+		isLoaded: false,
+
+		parseTemplate: function (data) {
+			var sec, opt, grp;
+			var secName, optName, grpName;
+			var isList;
+			console.log("UCI Templeate read");
+			data = data.data;
+			//console.log(data);
+
+			//add 'name' properties to each level
+			data.name = configFile
+			data.title = data.title || configFile;
+			if (!data.luci2) data.luci2 = {};
+
+
+
+			if (data.sections) {
+				for (secName in data.sections) {
+					sec = data.sections[secName];
+					sec.name = secName;
+					//console.log(sec);
+					//console.log(data.sections[sec]);
+
+					if (typeof (sec.title) == "undefined") sec.title = secName;
+					if (!sec.luci2) sec.luci2 = {};
+
+					if (!sec.luci2.addremove) delete sec.luci2.addremove;
+					if (!sec.luci2.anonymous) delete sec.luci2.anonymous;
+
+					//section has ungrouped options
+					self.parseOptions(sec.options);
+					
+					for( grpName in sec.groups) {
+						grp=sec.groups[grpName];
+						grp.nane=grpName;
+						grp.title=grp.title || grpName;
+						self.parseOptions(grp.options);
+					}
+						
+				}
+
+
+			}
+			//console.log("add names");
+			//console.log(data);
+
+			self.config = data;
+			self.isLoaded = true;
+			$scope.config = data;
+			$scope.isLoaded = true;
+		},
+		parseOptions: function (options) {
+			if(typeof(options)=='undefined') return;
+			
+			for (optName in options) {
+				opt = options[optName];
+				//console.log(opt);
+
+				opt.name = optName;
+				opt.title = opt.title || optName;
+
+				//if it is a list take the type from the first value
+				if (angular.isArray(opt.type)) {
+					isList = true;
+					opt.type = opt.type.length ? opt.type[0] : "string";
+				} else isList = undefined;
+
+				//get control information
+				if (!self.types[opt.type]) opt.type = 'string';
+				if (!angular.isObject(self.types[opt.type])) {
+					opt.type = {
+						elem: 'cbiInput',
+						validation: opt.type
+					}
+				} else opt.type = self.types[opt.type];
+				opt.type.isList = isList;
+
+
+				if (opt.values) {
+					if (!angular.isArray(opt.values)) opt.values = [opt.values];
+
+					if (opt.type.elem == "cbiFlag") {
+						if (opt.values.length >= 2) {
+							opt.type.attr = "on=" + opt.values[0] + " off="
+							opt.values[1];
+						}
+					} else opt.type.elem = 'cbiSelect';
+
+				}
+
+				
+				//calculate validate options
+				if(typeof(opt.required)=="undefined") opt.required=false;
+				
+				opt.validate = []
+				if (opt.type.validation) opt.validate.push(opt.type.validation);
+				if (opt.validation) opt.validate.push(opt.validation);
+				if (opt.values) opt.validate.push("or(" + opt.values.join(',') + ")");
+				opt.validate =  opt.validate.length > 1 ? ("and(" + opt.validate.join(',') + ")") : opt.validate.join(',');
+				opt.validate = (opt.required ? "require " : "optional ")  + opt.validate;
+
+			}
+
+		}
+	});
+
+	$http.get('system.json').then(this.parseTemplate, function (data) {
+		console.log("error reading config definition");
+		console.log(data);
+	});
+	}]);

--- a/luci2-ui-base/www/luci-ng/view/shared/uci_general.html
+++ b/luci2-ui-base/www/luci-ng/view/shared/uci_general.html
@@ -1,0 +1,47 @@
+<div ng-if="isLoaded">
+	<h1>{{config.title}}</h1>
+	<h3>{{config.description}}</h2>
+	<div cbi-map="{{config.name}}" waitfor="View.load()">
+		<div ng-repeat="section in config.sections">
+			<div cbi-section="{{config.name}}.@{{section.name}}" title="{{section.description}}" ng-attr-addremove="{{section.luci2.addremove}}" ng-attr-anonymous="{{section.luci2.anonymous}}" ng-attr-collapse="{{section.luci2.collapse}}" ng-attr-sortable="{{section.luci2.sortable}}">
+
+				<div ng-repeat="option in section.options" cbi-option="{{option.name}}" title="{{option.name}}" description="{{option.description}}" depends={{option.depends}} validate="{{option.validate}}" ng-attr-list="{{opt.type.isList}}">
+					<cbi-select ng-if="option.type.elem=='cbiSelect'" />
+					<cbi-input ng-if="option.type.elem=='cbiInput'" />
+					<cbi-flag ng-if="option.type.elem=='cbiFlag'" />
+					<cbi-device-list ng-if="option.type.elem=='cbiDeviceList'" />
+					<cbi-network-list ng-if="option.type.elem=='cbiNetworkList'" />
+				</div>
+
+				<div ng-if="section.groups">
+					<tabset>
+							<tab ng-repeat="group in section.groups" heading="{{group.title}}">
+								<div ng-repeat="option in group.options" cbi-option="{{option.name}}" title="{{option.title}}" description="{{option.description}}" depends={{option.depends}} validate="{{option.validate}}" ng-attr-list="{{opt.type.isList}}">
+									<div ng-switch="option.type.elem">
+										<div ng-switch-when="cbiInput">
+											<cbi-input />
+										</div>
+										<div ng-switch-when="cbiSelect">
+											<cbi-select />
+										</div>
+										<div ng-switch-when="cbiFlag">
+											<cbi-flag />
+										</div>
+										<div ng-switch-when="cbiDeviceList">
+											<cbi-device-list />
+										</div>
+										<div ng-switch-when="cbiNetworkList">
+											<cbi-network-list />
+										</div>
+									</div>
+								</div>
+							</tab>
+					</tabset>
+				</div>
+
+
+			</div>
+		</div>
+
+	</div>
+</div>

--- a/luci2-ui-base/www/system.json
+++ b/luci2-ui-base/www/system.json
@@ -1,0 +1,165 @@
+{
+	"title": "System Options",
+	"description": "Here you can configure the basic aspects of your device like its hostname or the timezone.",
+	"info": "this is a very long explanation",
+	"sections": {
+		"system": {
+			"description": "System Options",
+			"groups": {
+				"general": {
+					"options": {
+						"hostname": {
+							"type": "hostname",
+							"required": false,
+							"default": "lede",
+							"description": "The hostname for this system."
+						},
+						"timezone": {
+							"type": "string",
+							"required": false,
+							"default": "UTC",
+							"description": "The time zone that date and time should be rendered in by default."
+						},
+						"zonename": {
+							"type": "string",
+							"required": false,
+							"default": "UTC",
+							"description": "Only useful when using glibc and zoneinfo. The time zone that date and time should be rendered in by default.",
+							"info": "Suppose you want to use Brussels' timezone, set this value to Europe/Brussels. Possible values can be found by running (cd /usr/share/zoneinfo; find *).\nDepends: LIBC_USE_EGLIBC, PACKAGE_zoneinfo-*"
+						}
+
+					}
+				},
+				"logging": {
+					"options": {
+						"buffersize": {
+							"title": "Kernel log buffer size",
+							"type": "uintenger",
+							"required": false,
+							"default": "kernel specific",
+							"description": "Size of the kernel message buffer."
+						},
+						"conloglevel": {
+							"title": "Kernel log level",
+							"type": "uinteger",
+							"default": 7,
+							"values": {
+								"1": "Info",
+								"2": "Warning",
+								"3": "Debug"
+							},
+							"description": "Maximum log level for kernel messages to be logged to the console. Only messages with a level lower than this will be printed to the console.",
+							"info": "Higher level messages have lower log level number. Highest level messages are ones with log level 0. If you want more verbous messages in console put conloglevel to 8 if you want less messages lower conloglevel to 4 or even less."
+						},
+						"cronloglevel": {
+							"title": "Cron log level",
+							"type": "uinteger",
+							"default": 5,
+							"description": "The minimul level for cron messages to be logged to syslog. 0 will print all debug messages, 8 will log command executions, and 9 or higher will only log error messages."
+						},
+						"log_buffer_size": {
+							"title": "System log buffer size",
+							"type": "uinteger",
+							"default": 64,
+							"description": "Size of the system log buffer (in kiB)"
+						},
+						"log_file": {
+							"title": "Write system log to file",
+							"type": "string",
+							"default": "no log file",
+							"description": "File to write log messages to. The default is to not write a log in a file. The most often used location for a system log file is /var/log/messages."
+						},
+						"log_remote": {
+							"title": "Enable remote logging",
+							"type": "bool",
+							"default": 0
+						},
+						"log_ip": {
+							"title": "External system log server",
+							"type": "ipaddr",
+							"depends": {
+								"log_remote": 1
+							},
+							"description": "Messages will be logged to this server in addition to the local destination."
+						},
+						"log_port": {
+							"title": "External system port number",
+							"type": "port",
+							"default": 514,
+							"depends": {
+								"log_remote": 1
+							}
+						},
+						"log_proto": {
+							"title": "External System protocol",
+							"type": "string",
+							"required": false,
+							"default": "udp",
+							"values": ["tcp", "udp"],
+							"depends": {
+								"log_remote": 1
+							},
+							"description": "Sets the protocol to use for the connection."
+						},
+						"log_prefix": {
+							"title": "External system log prefix",
+							"type": "string",
+							"depends": {
+								"log_remote": 1
+							},
+							"description": "Adds a prefix to all log messages send over network."
+						},
+						"log_trailer_null": {
+							"title": "External system use null trailer over TCP",
+							"type": "bool",
+							"required": false,
+							"default": 0,
+							"depends": {
+								"log_remote": 1,
+								"log_proto": "tcp"
+							},
+							"description": "Use \\0 instead of \\n as trailer when using TCP."
+						}
+					}
+				}
+			}
+		},
+		"timeserver": {
+			"description": "Timeserver Options",
+			"options": {
+				"enable": {
+					"title": "Enable NTP service",
+					"type": "bool",
+					"default": 0,
+					
+					"description": "You can put busybox-ntpd in client mode only: by defining at least one host to server and puting enable_server 0 client & server mode: by putting enable_server to 1, (busybox-ntpd listens to UDP 123 by default), server mode only: by not defining any servers in the config and just put enable_server 1 (ntpd will answer with the time of the router)"
+				},
+				"enable_server": {
+					"title": "Enable local NTP server",
+					"type": "bool",
+					"default": 0,
+					"depends": {"enable":1}
+					
+				},
+				"server": {
+					"title": "NTP Servers to poll",
+					"type": ["host"],
+					"required": true,
+					"depends": {"enable":1},
+					"description": "Static list of servers to poll"
+				},
+				"use_dhcp": {
+					"title": "Get NTP servers from DHCP",
+					"type": "bool",
+					"depends": {"enable":1}
+				},
+				"dhcp_interface": {
+					"title": "Interfaces to listen to DHCP servers",
+					"type": ["string"],
+					"depends": {"enable":1, "use_dhcp":1}
+					
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a proof of concept and a WIP, not an actual PR. 
It implements a method for automatic generating LUCI pages for a UCI
config file.
I'd like to hear your views before developing any further. Sorry for the lengthy post.

The basic idea is to have LUCI interface for packages with near zero effort. Only 2 .json config file and no need for web programming or internal knowledge of the functions/directives of luci-ng; and no need for an additional luci-pkg-name (perhaps only for translations).
It is mainly intended for packages, the core config should have custom pages (although for the example I used the system config).

Steps:
1. create a <uci config>.json file with the description of the structure of the <UCI config file> itself. This is in way similar to the definitions embedded in the many init.d scripts in calls to `uci_validate_section section option:type:default`
I used json as it was easier to integrate in http and more flexible to add properties. But this _meta_ config file could be in any other format. In docs/autoUCI.json there is a description of a possible format.
2. add another .json with the mapping to the menu.d to make it appear in LUCI
3. all ready to use it in luci-ng

Thinking a little ahead, this description of the config file could be also used in init.d scripts, so that we don't have duplicate definitions of the same info, and we also ensure that changes in the config file go quicker to LUCI. (for instance in the system config the options to get NTP servers from DHCP were added, but never made it to LUCI interface).
With the proper hooks, this files could also populate the documentation/wiki tables describing the UCI params of each file.

For this proof of concept, the page is still hardcoded with a specific config file (it should be parameterized with the ngRouter), and monolithic, meaning that it edits the whole file at once or nothing. 
But the idea could be extended into the CBI directives, with some kind of "autoUCI" param so that it automatically generates the proper level: the whole config (like the example) if at cbiMap, or a specific section if at cbiSection (so that one con mix manual with automatic UI), or even at cbiOption level.

Signed-off-by: Adrian Panella ianchi74@outlook.com
