### PR TITLE
luci-ui-base: split backup acl into backup-action and backup-conf

### DIFF
--- a/luci2-ui-base/share/rpcd/acl.d/luci-ng.json
+++ b/luci2-ui-base/share/rpcd/acl.d/luci-ng.json
@@ -197,18 +197,12 @@
 		}
 	},
 
-	"backup": {
+	"backup-action": {
 		"description": "Backup and Restore",
 		"read": {
 			"luci-io": [
 				"backup"
-			],
-			"ubus": {
-				"luci2.system": [
-					"backup_config_get",
-					"backup_list"
-				]
-			}
+			]
 		},
 		"write": {
 			"luci-io": [
@@ -217,9 +211,27 @@
 			"ubus": {
 				"luci2.system": [
 					"backup_clean",
-					"backup_config_set",
 					"backup_restore",
 					"reboot"
+				]
+			}
+		}
+	},
+
+	"backup-conf": {
+		"description": "Backup configuration",
+		"read": {
+			"ubus": {
+				"luci2.system": [
+					"backup_config_get",
+					"backup_list"
+				]
+			}
+		},
+		"write": {
+			"ubus": {
+				"luci2.system": [
+					"backup_config_set"
 				]
 			}
 		}

--- a/luci2-ui-base/share/rpcd/menu.d/system.json
+++ b/luci2-ui-base/share/rpcd/menu.d/system.json
@@ -30,7 +30,7 @@
     },
     "system/backup": {
         "title": "Backup",
-        "acls": [ "backup" ],
+        "acls": [ "backup-action", "backup-conf" ],
         "view": "system/backup",
         "index": 50
     },


### PR DESCRIPTION
If an user is allowed to take a backup from the router he could also
edit the backup list. This is sometimes not workable, because a use
should not be always allowed to change the backup-list.

To make a difference between this the backup acl is now split.

backup-action:
Is allowed to make/apply a backup

backup-conf:
Can edit the backup-list

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>