### PR TITLE
RFC: Tabbed Navigation

### DIFF
--- a/luci2-ui-base/share/rpcd/menu.d/tabs.json
+++ b/luci2-ui-base/share/rpcd/menu.d/tabs.json
@@ -1,0 +1,32 @@
+{
+    "tabs": {
+        "title": "Tabbed",
+        "index": 50
+    },
+    "tabs/network": {
+        "title": "Network",
+        "tabbed": true,
+        "index": 10
+    },
+	
+	"tabs/network/status": {
+        "title": "Status",
+        "acls": [ "status" ],
+        "view": "status/routes",
+        "index": 10
+    },
+	
+	"tabs/network/basic": {
+        "title": "Basic",
+        "acls": [ "routes" ],
+        "view": "network/routes",
+        "index": 20
+    },
+	
+	"tabs/network/advanced": {
+        "title": "Advanced",
+        "acls": [ "routes" ],
+        "view": "network/routes",
+        "index": 30
+    }
+}

--- a/luci2-ui-base/src/www/amFramework/components/navTabs.js
+++ b/luci2-ui-base/src/www/amFramework/components/navTabs.js
@@ -1,0 +1,51 @@
+/**
+ * @ngdoc directive
+ * @name amfNavTabs
+ * @module amFramework
+ *
+ * @restrict E
+ *
+ * @description
+ * `<amf-nav-tabs>` Combines a Tabbed navigation with an ui-view routing.
+ * It provides sync of url/tabs and and embeded view content, integrated with ui-router.
+ * It is intended to be used directly in the 'component' attribute of a parent state.
+ * In a way it's similar to mdNavBar but it provides the bar pagination needed for scrolling in small devices,
+ * but only allows dynamic creation from an object data, and no explicit markup definition of tabs.
+ *
+ * @param tabs {!Array<Object>=} Array of tabs with title and sref data
+ *      following properties:
+ *      - `title` - `{string=}`: String to show on the tab
+ *      - `sref` - `{string=}`: State name to link this tab to
+ *      - `disabled` - `{bool=}`: True if the tab is disabled (not clickable)
+ *
+ */
+
+angular.module('amFramework')
+	.component('amfNavTabs', {
+		transclude: false,
+		bindings: { tabs: '<' },
+		templateUrl: 'amFramework/components/navTabs.tmpl.html',
+		controller: NavTabsCtrl
+	});
+
+
+function NavTabsCtrl($transitions, $state) {
+	var self = this;
+    // Private data
+	self.selectedIndex = 0;
+
+	self.$onDestroy = $transitions.onSuccess({ to: $state.$current.name + '.**' }, transHook);
+
+	self.syncSref = function(tab) {
+		$state.go(tab.sref);
+	};
+
+	function transHook(transition) {
+		var toSref = transition.$to().name;
+		for (var i=0; i<self.tabs.length; i++)
+			if ( toSref == self.tabs[i].sref) {
+				self.selectedIndex = i;
+				break;
+			}
+	}
+}

--- a/luci2-ui-base/src/www/amFramework/components/navTabs.tmpl.html
+++ b/luci2-ui-base/src/www/amFramework/components/navTabs.tmpl.html
@@ -1,0 +1,7 @@
+<md-tabs md-selected="$ctrl.selectedIndex" md-border-bottom md-stretch-tabs>
+	<md-tab ng-repeat="tab in $ctrl.tabs" ng-disabled="tab.disabled" label="{{tab.title}}"
+			md-on-select="$ctrl.syncSref(tab)"
+			></md-tab>
+</md-tabs>
+
+<ui-view></ui-view>

--- a/luci2-ui-base/src/www/luci-ng/ui/l2.menu.js
+++ b/luci2-ui-base/src/www/luci-ng/ui/l2.menu.js
@@ -24,11 +24,20 @@ angular.module('LuCI2')
 					data: { title: node.title }
 				};
 
-
-				if (node.childs)
+				if (node.tabs)
+					angular.extend( state, {
+						component: 'amfNavTabs',
+						resolve: {
+							tabs: function() {
+								return node.tabs;
+							}
+						}
+					});
+				else if (node.childs)
 					angular.extend( state, {
 						abstract: true,
-						template: '<div class="ui-view"></div>'
+						template: '<div class="ui-view"></div>',
+						redirectTo: node.childs[0].sref
 					});
 				else if (node.view)
 					angular.extend( state, {
@@ -80,9 +89,6 @@ angular.module('LuCI2')
 			childsArray: function(node) {
 				var childs = [];
 
-				var state = _menu.state(node);
-				_states.push(state);
-
 				for (var child in (node.childs || {})) {
 					_menu.childsArray(node.childs[child]);
 					childs.push(node.childs[child]);
@@ -90,11 +96,15 @@ angular.module('LuCI2')
 
 				childs.sort(_menu.cmp);
 
-				if (childs.length) {
+				if (childs.length && !node.tabbed) {
 					node.childs = childs;
-					state.redirectTo= childs[0].sref;
-				} else
+				} else {
 					delete node.childs;
+					if (childs.length && node.tabbed) node.tabs = childs;
+				}
+
+				var state = _menu.state(node);
+				_states.push(state);
 			},
 
 			registerStates: function() {


### PR DESCRIPTION
Added tabbed navigation for (last) level of menu definition.
Tabs are defined using the current menu.d approach, so all the validation of acl's and files still aplies.
The idea is to have fixed "Status | Basic | Advanced" tabs, but the logic is flexible to what is actually defined in the menu.
The tabs are rendered at the level where the property "tabbed" is set to 'true'.

Still pending to modify the Breadcrumbs to not repeat the last state, already shown by the tab.