### PR TITLE
luci2-ui-base: conditional node/host dependency

### DIFF
--- a/luci2-ui-base/Makefile
+++ b/luci2-ui-base/Makefile
@@ -15,7 +15,10 @@ PKG_LICENSE_FILES:=
 
 PKG_BUILD_PARALLEL:=1
 
+#add host dependency if node 4 or above is not installed
+ifneq ($(shell [[ $(node -v 2> /dev/null) =~ v([0-9]*)\. ]] && [ ${BASH_REMATCH[1]} -ge 4 ] && echo true),true)
 PKG_BUILD_DEPENDS:=node/host
+endif
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
@jow- I'm no expert at Bash/Makefiles, but I was trying something like this to conditionally 
add host dependency on Node only if it is not installed (or version prior to 4).
The idea was to avoid a lengthy and space consuming compilation.

But it doesn't seem to work. The host dependency is compiled anyway after a `make clean`
Any ideas or suggestions? Is there a more "natural" way of achieving this in LEDE's build system?