### PR TITLE
luci2-io-helper: fixing gcc 7 compilation error

### DIFF
--- a/luci2-io-helper/src/main.c
+++ b/luci2-io-helper/src/main.c
@@ -141,7 +141,7 @@ md5sum(const char *file)
 		close(fds[0]);
 		close(fds[1]);
 
-		if (execl("/bin/busybox", "/bin/busybox", "md5sum", file, NULL));
+		if (execl("/bin/busybox", "/bin/busybox", "md5sum", file, NULL))
 			return NULL;
 
 		break;


### PR DESCRIPTION
Fixing gcc 7 compilation error which is also a bug.